### PR TITLE
Remove 'container' property from NamespacedEntity

### DIFF
--- a/diagrams/metametamodel-gen.md
+++ b/diagrams/metametamodel-gen.md
@@ -95,7 +95,7 @@ classDiagram
   Metamodel "*" -- "*" Metamodel: dependsOn
 
 
-  NamespacedEntity "*" -- "1" NamespaceProvider: container
+
 
   Property "*" -- "1" DataType: type
 

--- a/diagrams/metametamodel-gen.puml
+++ b/diagrams/metametamodel-gen.puml
@@ -81,7 +81,7 @@ Metamodel "1" o-- "*" MetamodelElement: elements
 Metamodel "*" -- "*" Metamodel: dependsOn
 
 
-NamespacedEntity "*" -- "1" NamespaceProvider: container
+
 
 Property "*" -- "1" DataType: type
 

--- a/models/lioncore.json
+++ b/models/lioncore.json
@@ -40,8 +40,7 @@
     "children": {
       "LIonCore_M3_FeaturesContainer_features": [
         "LIonCore_M3_NamespacedEntity_simpleName",
-        "LIonCore_M3_NamespacedEntity_qualifiedName",
-        "LIonCore_M3_NamespacedEntity_container"
+        "LIonCore_M3_NamespacedEntity_qualifiedName"
       ]
     },
     "references": {
@@ -76,21 +75,6 @@
     "references": {
       "LIonCore_M3_Property_type": [
         "LIonCore_M3_String"
-      ]
-    }
-  },
-  {
-    "type": "LIonCore_M3_Reference",
-    "id": "LIonCore_M3_NamespacedEntity_container",
-    "properties": {
-      "LIonCore_M3_NamespacedEntity_simpleName": "container",
-      "LIonCore_M3_Feature_optional": false,
-      "LIonCore_M3_Feature_derived": false,
-      "LIonCore_M3_Link_multiple": false
-    },
-    "references": {
-      "LIonCore_M3_Link_type": [
-        "LIonCore_M3_NamespaceProvider"
       ]
     }
   },

--- a/schemas/lioncore.serialization.schema.json
+++ b/schemas/lioncore.serialization.schema.json
@@ -118,9 +118,6 @@
             },
             "LIonCore_M3_Concept_implements": {
               "$ref": "#/$defs/SerializedRefs"
-            },
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
             }
           },
           "additionalProperties": false
@@ -166,9 +163,6 @@
           "type": "object",
           "properties": {
             "LIonCore_M3_ConceptInterface_extends": {
-              "$ref": "#/$defs/SerializedRefs"
-            },
-            "LIonCore_M3_NamespacedEntity_container": {
               "$ref": "#/$defs/SerializedRefs"
             }
           },
@@ -224,9 +218,6 @@
           "properties": {
             "LIonCore_M3_Link_type": {
               "$ref": "#/$defs/SerializedRefs"
-            },
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
             }
           },
           "additionalProperties": false
@@ -281,9 +272,6 @@
           "properties": {
             "LIonCore_M3_Property_type": {
               "$ref": "#/$defs/SerializedRefs"
-            },
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
             }
           },
           "additionalProperties": false
@@ -323,11 +311,7 @@
         },
         "references": {
           "type": "object",
-          "properties": {
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
-            }
-          },
+          "properties": {},
           "additionalProperties": false
         }
       },
@@ -380,9 +364,6 @@
           "properties": {
             "LIonCore_M3_Link_type": {
               "$ref": "#/$defs/SerializedRefs"
-            },
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
             }
           },
           "additionalProperties": false
@@ -429,11 +410,7 @@
         },
         "references": {
           "type": "object",
-          "properties": {
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
-            }
-          },
+          "properties": {},
           "additionalProperties": false
         }
       },
@@ -471,11 +448,7 @@
         },
         "references": {
           "type": "object",
-          "properties": {
-            "LIonCore_M3_NamespacedEntity_container": {
-              "$ref": "#/$defs/SerializedRefs"
-            }
-          },
+          "properties": {},
           "additionalProperties": false
         }
       },

--- a/src/m3/self-definition.ts
+++ b/src/m3/self-definition.ts
@@ -54,13 +54,9 @@ const namespacedEntity_qualifiedName = factory.property(namespacedEntity, "quali
     .isDerived()
     .ofType(stringDatatype)
 
-const namespacedEntity_container = factory.reference(namespacedEntity, "container")
-    .ofType(namespaceProvider)
-
 namespacedEntity.havingFeatures(
         namespacedEntity_simpleName,
-        namespacedEntity_qualifiedName,
-        namespacedEntity_container
+        namespacedEntity_qualifiedName
     )
 
 


### PR DESCRIPTION
As agreed last meeting (Friday 2022-01-13). Most impact is in the Programming M3, i.e. the M3's implementation in terms of classes.